### PR TITLE
Rewrite installation selector JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.quarto/
+_website/

--- a/install/install.qmd
+++ b/install/install.qmd
@@ -10,18 +10,32 @@ popular languages. Most users can get started by just selecting their preferred
 options in the grid below. If you don't see your exact set-up, see (TODO) "Other Packages" below
 for more programming language options and ways of using Stan.
 
-<div id="install-grid" >
-<!-- Filled in by JS -->
-</div>
-<br />
-<div class="flex-grid">
-  <div class="row-label">Prerequisites</div>
-  <div class="col" id="prerequisites" style="background-color: var(--stan-highlight);padding-left:10px;"></div>
-</div>
-<div class="flex-grid">
-  <div class="row-label">How to Install</div>
-  <div class="col" id="command" style="background-color: var(--stan-highlight);padding-left:10px;"></div>
-</div>
+
+::: {#install-grid}
+ <!-- Filled in by JS -->
+:::
+
+::: {.flex-grid}
+
+:::: {.row-label}
+Prerequisites
+::::
+:::: {.col .highlight-box #prerequisites}
+
+::::
+
+:::
+
+::: {.flex-grid}
+
+:::: {.row-label}
+How to Install
+::::
+:::: {.col .highlight-box #command}
+
+::::
+
+:::
 
 <script src="installer.js"></script>
 

--- a/install/install.qmd
+++ b/install/install.qmd
@@ -89,6 +89,12 @@ For more information, see the
 [CmdStanR documentation](https://mc-stan.org/cmdstanr/articles/cmdstanr.html#installing-cmdstan){target="_blank"}
 :::::
 
+::::: {.install #install-cmdstanr-conda .hidden}
+Run `conda install -c conda-forge r-cmdstanr`.
+
+Note: this will also install CmdStan and any system prerequesites.
+:::::
+
 ::::: {.install #install-cmdstanr-github-src .hidden}
 In R, run `remotes::install_github("stan-dev/cmdstanr")`.
 Then run `cmdstanr::install_cmdstan()` or follow the manual installation instructions for CmdStan.
@@ -123,6 +129,11 @@ TODO 7
 :::::
 ::::: {.install #install-rstan-runiverse .hidden}
 TODO 8
+:::::
+::::: {.install #install-rstan-conda .hidden}
+Run `conda install -c conda-forge r-rstan`.
+
+Note: this will also install any system prerequesites.
 :::::
 ::::: {.install #install-rstan-github-src .hidden}
 TODO 9

--- a/install/install.qmd
+++ b/install/install.qmd
@@ -5,39 +5,23 @@ toc-location: left
 ---
 ## Download and Install Stan
 
-<div class="grid-container">
-  <div class="row-label">OS</div>
-  <div class="os option grid-item" id="linux">Linux</div>
-  <div class="os option grid-item" id="macos">MacOS</div>
-  <div class="os option grid-item" id="windows">Windows</div>
-  <div class="grid-blank"></div>
+Stan is available for all major operating systems and has packages in several
+popular languages. Most users can get started by just selecting their preferred
+options in the grid below. If you don't see your exact set-up, see (TODO) "Other Packages" below
+for more programming language options and ways of using Stan.
 
-  <div class="row-label" style="grid-row: span 2;">Interface</div>
-  <div class="interface option grid-item" id="stan.jl">Julia</div>
-  <div class="interface option grid-item" id="cmdstanpy">CmdStanPy</div>
-  <div class="interface option grid-item" id="cmdstanr">CmdStanR</div>
-  <div class="interface option grid-item" id="cmdstan">CmdStan</div>
-  <div class="grid-blank"></div>
-  <div class="interface option grid-item" style="grid-column: 3;" id="pystan">PyStan</div>
-  <div class="interface option grid-item" style="grid-column: 4;" id="rstan">RStan</div>
-  <div class="grid-blank"></div>
-
-  <div class="row-label" style="grid-row: span 2;">Installer</div>
-  <div class="installer option grid-item" id="julia-pkg">Julia package manager</div>
-  <div class="installer option grid-item" id="pip">Pip</div>
-  <div class="installer option grid-item" id="cran">CRAN</div>
-  <div class="installer option grid-item" id="github-bin">Github binary</div>
-  <div class="grid-blank"></div>
-  <div class="installer option grid-item" id="conda">Conda-forge</div>
-  <div class="installer option grid-item" id="runiverse">R Universe</div>
-  <div class="installer option grid-item" id="github-src">Github source</div>
-
-  <br/>
-  <div class="row-label" style="grid-column:1;">Command&nbsp;&nbsp;&nbsp;</div>
-  <div class="grid-item row-label" id="command"
-       style="grid-column:span 4; background-color: var(--stan-highlight);padding-left:10px;">
+<div id="install-grid" >
+</div>
+<br/>
+<div class="flex-grid">
+  <div class="row-label">Prerequisites</div>
+  <div class="col" id="prerequisites" style="background-color: var(--stan-highlight);padding-left:10px;">
   </div>
-  <br/>
+</div>
+<div class="flex-grid">
+  <div class="row-label">How to Install</div>
+  <div class="col" id="command" style="background-color: var(--stan-highlight);padding-left:10px;">
+  </div>
 </div>
 
 <script src="installer_2.js"></script>

--- a/install/install.qmd
+++ b/install/install.qmd
@@ -7,7 +7,7 @@ toc-location: left
 
 Stan is available for all major operating systems and has packages in several
 popular languages. Most users can get started by just selecting their preferred
-options in the grid below. If you don't see your exact set-up, see (TODO) "Other Packages" below
+options in the grid below. If you don't see your exact set-up, see [Other packages and environments](#other-packages) below
 for more programming language options and ways of using Stan.
 
 
@@ -157,7 +157,7 @@ TODO 11
 - Conda
 - RTools
 
-## Other packages and environments
+## Other packages and environments {#other-packages}
 
 #### Google Colab
 

--- a/install/install.qmd
+++ b/install/install.qmd
@@ -15,31 +15,132 @@ for more programming language options and ways of using Stan.
  <!-- Filled in by JS -->
 :::
 
-::: {.flex-grid}
-
+<!-- The following two boxes contain divs which are hidden/unhidden based on the above grid.
+  They can contain normal markdown as we see fit
+ -->
+::: {#prerequsite-box .flex-grid}
 :::: {.row-label}
 Prerequisites
 ::::
-:::: {.col .highlight-box #prerequisites}
+:::: {.col .highlight-box}
+
+::::: {.prereq #prereq-windows .hidden}
+Stan requires a C++17 compiler and some additional tools for building. The `conda`
+option of certain packages can install these for you, or we recommend RTools TODO
+:::::
+
+::::: {.prereq #prereq-macos .hidden}
+Stan requires a C++17 compiler. The `conda` option of certain packages can install
+this for you, or we recommend to install Xcode from the App Store and then run `xcode-select --install`.
+:::::
+
+::::: {.prereq #prereq-linux .hidden}
+Stan requires a C++17 compiler. The `conda` option of certain packages can install
+this for you, or on .deb based distros, `sudo apt-get install build-essential` will install what you need.
+:::::
 
 ::::
 
 :::
 
-::: {.flex-grid}
+::: {#install-box .flex-grid}
 
 :::: {.row-label}
 How to Install
 ::::
-:::: {.col .highlight-box #command}
+:::: {.col .highlight-box}
+
+::::: {.install #install-please-select}
+Please select interface and preferred package manager.
+:::::
+
+<!-- ---------- CmdStanPy ---------- -->
+
+::::: {.install #install-cmdstanpy-pip .hidden}
+Run `pip install cmdstanpy`. Then, in Python, run
+`import cmdstanpy; cmdstanpy.install_cmdstan()` or follow the manual
+installation instructions for CmdStan.
+
+For more information, see the
+[CmdStanPy documentation](https://mc-stan.org/cmdstanpy/installation.html){target="_blank"}.
+:::::
+
+::::: {.install #install-cmdstanpy-conda .hidden}
+Run `conda install -c conda-forge cmdstanpy`.
+
+Note: this will also install CmdStan and any system prerequesites.
+:::::
+
+::::: {.install #install-cmdstanpy-github-src .hidden}
+Run `pip install -e git+https://github.com/stan-dev/cmdstanpy@develop#egg=cmdstanpy`.
+Then, in Python, run `import cmdstanpy; cmdstanpy.install_cmdstan()`
+or follow the manual installation instructions for CmdStan.
+
+For more information, see the
+[CmdStanPy documentation](https://mc-stan.org/cmdstanpy/installation.html){target="_blank"}.
+:::::
+
+<!-- ---------- CmdStanR ---------- -->
+::::: {.install #install-cmdstanr-runiverse .hidden}
+In R, run `install.packages("cmdstanr", repos = c('https://stan-dev.r-universe.dev', getOption("repos")))`.
+Then run `cmdstanr::install_cmdstan()` or follow the manual installation instructions for CmdStan.
+
+For more information, see the
+[CmdStanR documentation](https://mc-stan.org/cmdstanr/articles/cmdstanr.html#installing-cmdstan){target="_blank"}
+:::::
+
+::::: {.install #install-cmdstanr-github-src .hidden}
+In R, run `remotes::install_github("stan-dev/cmdstanr")`.
+Then run `cmdstanr::install_cmdstan()` or follow the manual installation instructions for CmdStan.
+
+For more information, see the
+[CmdStanR documentation](https://mc-stan.org/cmdstanr/articles/cmdstanr.html#installing-cmdstan){target="_blank"}
+:::::
+
+<!-- ---------- CmdStan ---------- -->
+::::: {.install #install-cmdstan-github-rel .hidden}
+TODO 1
+:::::
+::::: {.install #install-cmdstan-conda .hidden}
+TODO 2
+:::::
+::::: {.install #install-cmdstan-github-src .hidden}
+TODO 3
+:::::
+<!-- ---------- Pystan ---------- -->
+::::: {.install #install-pystan-pip .hidden}
+TODO 4
+:::::
+::::: {.install #install-pystan-conda .hidden}
+TODO 5
+:::::
+::::: {.install #install-pystan-github-src .hidden}
+TODO 6
+:::::
+<!-- ---------- RStan ---------- -->
+::::: {.install #install-rstan-cran .hidden}
+TODO 7
+:::::
+::::: {.install #install-rstan-runiverse .hidden}
+TODO 8
+:::::
+::::: {.install #install-rstan-github-src .hidden}
+TODO 9
+:::::
+<!-- ---------- Stan.jl ---------- -->
+::::: {.install #install-stan.jl-julia-pkg .hidden}
+TODO 10
+:::::
+::::: {.install #install-stan.jl-github-src .hidden}
+TODO 11
+:::::
 
 ::::
-
 :::
 
 <script src="installer.js"></script>
 
-## Instructions
+## In-Depth Instructions
 
 ### Platform
 
@@ -54,18 +155,13 @@ How to Install
 #### Windows
 
 - Conda
+- RTools
 
-### Language
-
-#### Julia
-
-#### Python
-
-#### R
-
-#### command shell
+## Other packages and environments
 
 #### Google Colab
+
+#### Mathematica, Stata, etc?
 
 ## Troubleshooting
 
@@ -79,7 +175,6 @@ How to Install
 
 ### GPU Support
 
-### RTools
 
 
 

--- a/install/install.qmd
+++ b/install/install.qmd
@@ -11,21 +11,19 @@ options in the grid below. If you don't see your exact set-up, see (TODO) "Other
 for more programming language options and ways of using Stan.
 
 <div id="install-grid" >
+<!-- Filled in by JS -->
 </div>
-<br/>
+<br />
 <div class="flex-grid">
   <div class="row-label">Prerequisites</div>
-  <div class="col" id="prerequisites" style="background-color: var(--stan-highlight);padding-left:10px;">
-  </div>
+  <div class="col" id="prerequisites" style="background-color: var(--stan-highlight);padding-left:10px;"></div>
 </div>
 <div class="flex-grid">
   <div class="row-label">How to Install</div>
-  <div class="col" id="command" style="background-color: var(--stan-highlight);padding-left:10px;">
-  </div>
+  <div class="col" id="command" style="background-color: var(--stan-highlight);padding-left:10px;"></div>
 </div>
 
-<script src="installer_2.js"></script>
-
+<script src="installer.js"></script>
 
 ## Instructions
 

--- a/install/installer.js
+++ b/install/installer.js
@@ -215,6 +215,7 @@ function addRow(label, items) {
 
 // Draw grid and select defaults
 document.addEventListener('DOMContentLoaded', function () {
+    document.getElementById('install-grid').innerHTML = '';
     addRow('OS', supportedOperatingSystems);
     addRow('Interface', supportedInterfaces);
     addRow('Installer', supportedInstallers);

--- a/install/installer.js
+++ b/install/installer.js
@@ -11,7 +11,10 @@ const supportedInstallersMap = {
     "": [], // mostly handles the case where a user had selected pystan then switches to windows
 };
 
-const cmdstanpyPostamble = "<p>Then, in Python, run <code>import cmdstanpy; cmdstanpy.install_cmdstan()</code> or follow the conda instructions for CmdStan</p>";
+const cmdstanpyPostamble = `
+<p>Then, in Python, run <code>import cmdstanpy; cmdstanpy.install_cmdstan()</code> or follow the conda instructions for CmdStan.</p>
+<p>For more information, see the <a href="https://mc-stan.org/cmdstanpy/installation.html" target="_blank">CmdStanPy documentation</a>.</p>
+`;
 const cmdstanRPostamble = "<p>Then run <code>cmdstanr::install_cmdstan()</code></p>";
 
 const instructions = {

--- a/install/installer.js
+++ b/install/installer.js
@@ -3,10 +3,10 @@ let supportedInterfaces = ['cmdstanpy', 'cmdstanr', 'cmdstan', 'pystan', 'rstan'
 
 const supportedInstallersMap = {
     "cmdstanpy": ["pip", "conda", "github-src"],
-    "cmdstanr": ["runiverse", "github-src"],
+    "cmdstanr": ["runiverse", "conda", "github-src"],
     "cmdstan": ["github-rel", "conda", "github-src"],
     "pystan": ["pip", "conda", "github-src"],
-    "rstan": ["cran", "runiverse", "github-src"],
+    "rstan": ["cran", "runiverse", "conda", "github-src"],
     "stan.jl": ["julia-pkg", "github-src"],
     "": [], // mostly handles the case where a user had selected pystan then switches to windows
 };

--- a/install/installer.js
+++ b/install/installer.js
@@ -11,40 +11,6 @@ const supportedInstallersMap = {
     "": [], // mostly handles the case where a user had selected pystan then switches to windows
 };
 
-const cmdstanpyPostamble = `
-<p>Then, in Python, run <code>import cmdstanpy; cmdstanpy.install_cmdstan()</code> or follow the conda instructions for CmdStan.</p>
-<p>For more information, see the <a href="https://mc-stan.org/cmdstanpy/installation.html" target="_blank">CmdStanPy documentation</a>.</p>
-`;
-const cmdstanRPostamble = "<p>Then run <code>cmdstanr::install_cmdstan()</code></p>";
-
-const instructions = {
-    "cmdstanpy": {
-        "pip": "Run <code>pip install cmdstanpy</code>" + cmdstanpyPostamble,
-        "conda": "Run <code>conda install -c conda-forge cmdstanpy</code>",
-        "github-src": "Run <code>pip install -e git+https://github.com/stan-dev/cmdstanpy@develop#egg=cmdstanpy</code>" + cmdstanpyPostamble,
-    },
-    "cmdstanr": {
-        "runiverse": "In R, run <code>install.packages(\"cmdstanr\", repos = c('https://stan-dev.r-universe.dev', getOption(\"repos\")))</code>" + cmdstanRPostamble,
-        "github-src": "In R, run <code>remotes::install_github(\"stan-dev/cmdstanr\")</code>" + cmdstanRPostamble,
-    },
-    "cmdstan": {
-        "github-rel": "install from github release binary.tgz",
-        "conda": "Run <code>conda install -c conda-forge cmdstan</code>",
-        "github-src": "install from github release src.tgz",
-    },
-    "pystan": {
-        "pip": "Run <code>pip install pystan</code>",
-        "conda": "Run <code>conda install -c conda-forge pystan</code>",
-    }
-    // TODO: more
-}
-
-const prerequisites = {
-    "linux": "Stan requires a C++17 compiler. On .deb based distros, <code>sudo apt-get install build-essential</code> will install what you need.",
-    "macos": "Stan requires a C++17 compiler. We recommend installing Xcode from the App Store and then run <code>xcode-select --install</code>.",
-    "windows": "Stan requires a C++17 compiler and some additional tools for building. We recommend RTools TODO",
-};
-
 const osToTitle = {
     "linux": "Linux",
     "macos": "macOS",
@@ -98,25 +64,32 @@ function selectedOption(selection, category) {
         }
     });
     opts[category] = selection;
-    updateInstructions();
-}
-
-function isOptionSet(category) {
-    return opts[category] && opts[category] !== '';
 }
 
 function updateInstructions() {
-    const prereq = prerequisites[opts.os];
-    document.getElementById('prerequisites').innerHTML = prereq ?? "Prerequisites not available.";
+    const prereqs = document.querySelectorAll('.prereq');
+    prereqs.forEach(prereq => {
+        prereq.classList.remove('hidden');
+        if (prereq.id !== `prereq-${opts.os}`) {
+            prereq.classList.add('hidden');
+        }
+    });
 
-    if (!isOptionSet('os') || !isOptionSet('interface') || !isOptionSet('installer')) {
-        document.getElementById('command').innerText = "Please select interface and preferred package manager.";
-        return;
+    const instructions = document.querySelectorAll('.install');
+    const key = `install-${opts.interface}-${opts.installer}`;
+    let found = false;
+    instructions.forEach(instruction => {
+        instruction.classList.remove('hidden');
+        if (instruction.id !== key) {
+            instruction.classList.add('hidden');
+        } else {
+            found = true;
+        }
+    });
+
+    if (!found) {
+        document.getElementById('install-please-select').classList.remove('hidden');
     }
-
-
-    const command = instructions[opts.interface]?.[opts.installer];
-    document.getElementById('command').innerHTML = command ?? "Instructions not available.";
 }
 
 function updateInterfaceOptions() {

--- a/install/installer.js
+++ b/install/installer.js
@@ -11,21 +11,28 @@ const supportedInstallersMap = {
     "": [], // mostly handles the case where a user had selected pystan then switches to windows
 };
 
+const cmdstanpyPostamble = "<p>Then, in Python, run <code>import cmdstanpy; cmdstanpy.install_cmdstan()</code> or follow the conda instructions for CmdStan</p>";
+const cmdstanRPostamble = "<p>Then run <code>cmdstanr::install_cmdstan()</code></p>";
+
 const instructions = {
     "cmdstanpy": {
-        "pip": "<code>pip install cmdstanpy</code>",
-        "conda": "<code>conda install -c conda-forge cmdstanpy</code>",
-        "github-src": "<code>pip install -e git+https://github.com/stan-dev/cmdstanpy@develop#egg=cmdstanpy</code>",
+        "pip": "Run <code>pip install cmdstanpy</code>" + cmdstanpyPostamble,
+        "conda": "Run <code>conda install -c conda-forge cmdstanpy</code>",
+        "github-src": "Run <code>pip install -e git+https://github.com/stan-dev/cmdstanpy@develop#egg=cmdstanpy</code>" + cmdstanpyPostamble,
     },
     "cmdstanr": {
-        "runiverse": "In R, run <code>install.packages(\"cmdstanr\", repos = c('https://stan-dev.r-universe.dev', getOption(\"repos\")))</code>",
-        "github-src": "In R, run <code>remotes::install_github(\"stan-dev/cmdstanr\")</code>",
+        "runiverse": "In R, run <code>install.packages(\"cmdstanr\", repos = c('https://stan-dev.r-universe.dev', getOption(\"repos\")))</code>" + cmdstanRPostamble,
+        "github-src": "In R, run <code>remotes::install_github(\"stan-dev/cmdstanr\")</code>" + cmdstanRPostamble,
     },
     "cmdstan": {
         "github-rel": "install from github release binary.tgz",
-        "conda": "<code>conda install -c conda-forge cmdstan</code>",
+        "conda": "Run <code>conda install -c conda-forge cmdstan</code>",
         "github-src": "install from github release src.tgz",
     },
+    "pystan": {
+        "pip": "Run <code>pip install pystan</code>",
+        "conda": "Run <code>conda install -c conda-forge pystan</code>",
+    }
     // TODO: more
 }
 

--- a/install/installer.js
+++ b/install/installer.js
@@ -36,6 +36,12 @@ const instructions = {
     // TODO: more
 }
 
+const prerequisites = {
+    "linux": "Stan requires a C++17 compiler. On .deb based distros, <code>sudo apt-get install build-essential</code> will install what you need.",
+    "macos": "Stan requires a C++17 compiler. We recommend installing Xcode from the App Store and then run <code>xcode-select --install</code>.",
+    "windows": "Stan requires a C++17 compiler and some additional tools for building. We recommend RTools TODO",
+};
+
 const osToTitle = {
     "linux": "Linux",
     "macos": "macOS",
@@ -97,11 +103,14 @@ function isOptionSet(category) {
 }
 
 function updateInstructions() {
+    const prereq = prerequisites[opts.os];
+    document.getElementById('prerequisites').innerHTML = prereq ?? "Prerequisites not available.";
+
     if (!isOptionSet('os') || !isOptionSet('interface') || !isOptionSet('installer')) {
-        document.getElementById('prerequisites').innerText = "";
-        document.getElementById('command').innerText = "Please select OS, interface, and preferred package manager.";
+        document.getElementById('command').innerText = "Please select interface and preferred package manager.";
         return;
     }
+
 
     const command = instructions[opts.interface]?.[opts.installer];
     document.getElementById('command').innerHTML = command ?? "Instructions not available.";

--- a/theming/quarto_styles.css
+++ b/theming/quarto_styles.css
@@ -1,30 +1,27 @@
 /* quarto website styling */
 
 @media (min-width: 1020px) {
-.navbar-brand-container {
-  margin-right: 1em;
-}
+  .navbar-brand-container {
+    margin-right: 1em;
+  }
 }
 
 @media (max-width: 1060px) and (min-width: 991.98px) {
+  #navbarCollapse ul:last-of-type a.nav-link {
+    padding-left: 0.25em;
+    padding-right: 0.25em;
+  }
 
-#navbarCollapse ul:last-of-type a.nav-link {
-  padding-left: .25em;
-  padding-right: .25em;
+  .navbar #quarto-search {
+    margin-left: 0.1em;
+  }
 }
-
-.navbar #quarto-search {
-  margin-left: .1em;
-}
-}
-
 
 @media (min-width: 991.98px) {
-#quarto-header {
-  border-bottom: 1px solid
+  #quarto-header {
+    border-bottom: 1px solid;
+  }
 }
-}
-
 
 .navbar-brand > img {
   max-height: 36px;
@@ -51,7 +48,7 @@
 }
 
 .document-example .citation {
-    color: var(--stan-secondary);
+  color: var(--stan-secondary);
 }
 
 .trademark {
@@ -80,19 +77,19 @@
 
 .download-table .checksum {
   color: var(--bs-primary);
-  font-size: .775em;
+  font-size: 0.775em;
   cursor: pointer;
   padding-top: 4px;
 }
 
 .download-button {
-  display:flex;
+  display: flex;
   padding-bottom: 10px;
   padding-top: 10px;
 }
 
 .download-button .secondary {
-  font-size: .775em;
+  font-size: 0.775em;
   margin-bottom: 0;
 }
 
@@ -121,32 +118,29 @@ iframe.reveal-demo {
 }
 
 @media only screen and (max-width: 600px) {
- .slide-deck {
+  .slide-deck {
     height: 400px;
   }
 }
 
 @media (max-width: 575px) {
-.link-cards .card {
-  margin-bottom: 20px;
-  margin-right: 35px;
-}
-
+  .link-cards .card {
+    margin-bottom: 20px;
+    margin-right: 35px;
+  }
 }
 
 @media (min-width: 576px) {
-.link-cards {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-}
+  .link-cards {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
 
-.link-cards .card {
-  width: 190px;
-  margin: 0 20px 12px 0;
-}
-
-
+  .link-cards .card {
+    width: 190px;
+    margin: 0 20px 12px 0;
+  }
 }
 
 .link-cards .card {
@@ -258,12 +252,12 @@ iframe.reveal-demo {
 .panel-tabset[data-group="tools-tabset"] .nav-tabs .nav-link,
 .panel-tabset[data-group="tools-tabset"] .nav-tabs .nav-link.active,
 .panel-tabset[data-group="tools-tabset"] .nav-tabs .nav-item.show .nav-link {
-  border: 1px solid  var(--stan-highlight);
+  border: 1px solid var(--stan-highlight);
   border-radius: 10px;
 }
 .panel-tabset[data-group="tools-tabset"] .nav-tabs .nav-link:hover {
-   border-color: var(--stan-secondary);
-   border-width: 1px;
+  border-color: var(--stan-secondary);
+  border-width: 1px;
 }
 
 .panel-tabset[data-group="tools-tabset"] .nav-tabs .nav-link.active,
@@ -285,7 +279,7 @@ iframe.reveal-demo {
 }
 
 .preview-image-grid {
-  gap: .75em;
+  gap: 0.75em;
 }
 
 .preview-image-grid p {
@@ -294,7 +288,7 @@ iframe.reveal-demo {
 
 .preview-image-label {
   text-align: center;
-  font-size: .75em;
+  font-size: 0.75em;
   font-weight: 600;
 }
 
@@ -304,16 +298,23 @@ iframe.reveal-demo {
 
 /* stan-dev custom styling */
 
-a { color: var(--stan-secondary);}
-a.nav-link.active { color: var(--stan-secondary);}
-a.sidebar-item-text.sidebar-link.active { color: var(--stan-secondary); }
-.sidebar.a.active { color: var(--stan-secondary); }
-
+a {
+  color: var(--stan-secondary);
+}
+a.nav-link.active {
+  color: var(--stan-secondary);
+}
+a.sidebar-item-text.sidebar-link.active {
+  color: var(--stan-secondary);
+}
+.sidebar.a.active {
+  color: var(--stan-secondary);
+}
 
 div [data-bs-target^="#quarto-sidebar-section"] {
-    font-weight: bold;
-    font-style: italic;
-    color: var(--stan-secondary);
+  font-weight: bold;
+  font-style: italic;
+  color: var(--stan-secondary);
 }
 
 p.big-top {
@@ -321,30 +322,30 @@ p.big-top {
 }
 
 code {
-    white-space: inherit;
-    color: var(--bs-dark-warm);
-    background-color: var(--stan-bg);
+  white-space: inherit;
+  color: var(--bs-dark-warm);
+  background-color: var(--stan-bg);
 }
 
 code:not(.sourceCode) {
-    color: var(--bs-dark-warm);
-    background-color: var(--stan-bg);
+  color: var(--bs-dark-warm);
+  background-color: var(--stan-bg);
 }
 
 p code {
-    white-space: inherit;
-    color: var(--bs-dark-warm);
-    background-color: var(--stan-bg);
+  white-space: inherit;
+  color: var(--bs-dark-warm);
+  background-color: var(--stan-bg);
 }
 
 p code:not(.sourceCode) {
-    color: var(--bs-dark-warm);
-    background-color: var(--stan-bg);
+  color: var(--bs-dark-warm);
+  background-color: var(--stan-bg);
 }
 
 li code:not(.sourceCode) {
-    color: var(--bs-dark-warm);
-    background-color: var(--stan-bg);
+  color: var(--bs-dark-warm);
+  background-color: var(--stan-bg);
 }
 
 td code:not(.sourceCode) {
@@ -353,62 +354,65 @@ td code:not(.sourceCode) {
 }
 
 pre {
-    word-break: normal;
-    word-wrap: normal;
-    color: var(--bs-dark-warm);
-    background-color: var(--stan-bg);
+  word-break: normal;
+  word-wrap: normal;
+  color: var(--bs-dark-warm);
+  background-color: var(--stan-bg);
 }
 pre code {
-    white-space: inherit;
-    margin: 0;
-    padding: 0;
-    color: var(--bs-dark-warm);
-    background-color: var(--stan-bg);
+  white-space: inherit;
+  margin: 0;
+  padding: 0;
+  color: var(--bs-dark-warm);
+  background-color: var(--stan-bg);
 }
 
 pre.sourceCode {
-    white-space: inherit;
-    margin: 0;
-    padding: 0;
-    color: var(--bs-dark-warm);
-    background-color: var(--stan-bg);
+  white-space: inherit;
+  margin: 0;
+  padding: 0;
+  color: var(--bs-dark-warm);
+  background-color: var(--stan-bg);
 }
 
 #quarto-appendix {
-    color: var(--bs-dark-warm);
-    background-color: var(--stan-bg);
+  color: var(--bs-dark-warm);
+  background-color: var(--stan-bg);
 }
 
 .align-equations {
-    text-align: left;
-    margin-left: 2em; /* Adjust as needed */
+  text-align: left;
+  margin-left: 2em; /* Adjust as needed */
 }
 
 .book .book-body .page-wrapper .page-inner section.normal pre {
-    font-family: "Lucida Console", Monaco, Menlo, monospaced;
-    margin-left: 2em;
-    margin-below: 0.6em;
-    margin-above: -0.3em;
-    padding: 0;
+  font-family: "Lucida Console", Monaco, Menlo, monospaced;
+  margin-left: 2em;
+  margin-below: 0.6em;
+  margin-above: -0.3em;
+  padding: 0;
 }
 
-.sidebar.sidebar-navigation>* {
-    padding-top: 0em;
+.sidebar.sidebar-navigation > * {
+  padding-top: 0em;
 }
 
-
-#quarto-sidebar > div.sidebar-menu-container > ul > li:nth-child(1) > div > a > span {
-    font-weight: bold;
-    font-style: italic;
-    font-size: 1.3em;
-    color: var(--stan-secondary);
-    margin-above: -20em;
-    padding: 0;
+#quarto-sidebar
+  > div.sidebar-menu-container
+  > ul
+  > li:nth-child(1)
+  > div
+  > a
+  > span {
+  font-weight: bold;
+  font-style: italic;
+  font-size: 1.3em;
+  color: var(--stan-secondary);
+  margin-above: -20em;
+  padding: 0;
 }
-
 
 /* quarto landing page styling */
-
 
 .hero-banner {
   position: relative;
@@ -453,37 +457,51 @@ pre.sourceCode {
 }
 
 .grid-container {
-    display: grid;
-    grid-template-columns: auto repeat(4, 1fr);
-    gap: 0px;
-    width: 80%;
+  display: grid;
+  grid-template-columns: auto repeat(4, 1fr);
+  gap: 0px;
+  width: 80%;
 }
 .option {
-    border: 1px solid var(--stan-dark);
-    text-align: center;
-    cursor: pointer;
+  border: 1px solid var(--stan-dark);
+  text-align: center;
+  cursor: pointer;
 }
 .option.selected {
-    background-color: var(--stan-highlight);
-    color: var(--stan-dark);
+  background-color: var(--stan-highlight);
+  color: var(--stan-dark);
 }
 .option.disabled {
-    cursor: not-allowed;
-    color: var(--stan-highlight);
+  cursor: not-allowed;
+  color: var(--stan-highlight);
 }
 .grid-item {
-    padding: 10px;
-    border: 1px solid var(--stan-dark);
-    color: var(--stan-dark);
+  padding: 10px;
+  border: 1px solid var(--stan-dark);
+  color: var(--stan-dark);
 }
+.grid-item + .grid-item {
+  border-left: 0px;
+}
+
 .grid-blank {
-    border: 0px;
-    background-color: var(--stan-bg);
+  border: 0px;
+  background-color: var(--stan-bg);
 }
 .row-label {
-    padding: 10px;
-    color: var(--stan-dark);
-    background-color: var(--stan-bg);
-    font-weight: bold;
-    text-align: left;
+  padding: 10px;
+  color: var(--stan-dark);
+  background-color: var(--stan-bg);
+  font-weight: bold;
+  text-align: left;
+  width: 20%;
+}
+
+.flex-grid {
+  display: flex;
+}
+
+.flex-grid .col {
+  flex: 1;
+  margin-top: 0.25rem;
 }

--- a/theming/quarto_styles.css
+++ b/theming/quarto_styles.css
@@ -505,3 +505,8 @@ pre.sourceCode {
   flex: 1;
   margin-top: 0.25rem;
 }
+
+.highlight-box {
+  background-color: var(--stan-highlight);
+  padding-left: 10px;
+}


### PR DESCRIPTION
This rewrites the install page such that:

1. The grid is generated by the JS. This, in particular, means we don't need to show so many disabled options all the time
2. The actual content is stored in the markdown file, which makes it easier to edit
3. I started writing the actual content

Screenshot:
![image](https://github.com/user-attachments/assets/3496cbf3-1502-4023-a6a7-9c034ee33b14)
