### PR TITLE
brms can use RStan (in fact that's the default)

### DIFF
--- a/install/install.qmd
+++ b/install/install.qmd
@@ -285,7 +285,7 @@ See CmdStan Guide section [Troubleshooting the Installation](https://mc-stan.org
 
 | **Language** | **Tool** | **Description** |
 |--------------|----------|-----------------|
-| **R**        | [**brms**](https://paul-buerkner.github.io/brms/){target="_blank"} | Use extended `lme4`-like formula syntax to specify and fit multivariate and multilevel models in Stan. *(Requires CmdStanR and C++ compiler.)* |
+| **R**        | [**brms**](https://paul-buerkner.github.io/brms/){target="_blank"} | Use extended `lme4`-like formula syntax to specify and fit multivariate and multilevel models in Stan. *(Requires CmdStanR or RStan and C++ compiler.)* |
 | **R**        | [**RStanArm**](https://mc-stan.org/rstanarm){target="_blank"} | Provides stable, efficient Stan versions of R model-fitting packages. *(Stan models are pre-compiled, no C++ compiler needed.)* |
 | **R**        | [**Rethinking**](https://github.com/rmcelreath/rethinking){target="_blank"} | Accompanies the book and course materials for [Statistical Rethinking, 2nd Ed](https://www.taylorfrancis.com/books/mono/10.1201/9780429029608/statistical-rethinking-richard-mcelreath){target="_blank"} by Richard McElreath. *(Requires CmdStanR and C++ compiler.)*|
 : {tbl-colwidths="[10, 15, 75]"}

--- a/tools/tools.qmd
+++ b/tools/tools.qmd
@@ -34,7 +34,7 @@ For detailed installation instructions see [Getting Started](../install/install.
 
 | **Language** | **Tool** | **Description** |
 |--------------|----------|-----------------|
-| **R**        | [**brms**](https://paul-buerkner.github.io/brms/){target="_blank"} | Use extended `lme4`-like formula syntax to specify and fit multivariate and multilevel models in Stan. *(Requires CmdStanR and C++ compiler.)* |
+| **R**        | [**brms**](https://paul-buerkner.github.io/brms/){target="_blank"} | Use extended `lme4`-like formula syntax to specify and fit multivariate and multilevel models in Stan. *(Requires CmdStanR or RStan and C++ compiler.)* |
 | **R**        | [**rstanarm**](https://mc-stan.org/rstanarm){target="_blank"} | Provides stable, efficient Stan versions of R model-fitting packages.  Installs easily from CRAN, no C++ compiler needed. |
 : {tbl-colwidths="[10, 20, 70]"}
 


### PR DESCRIPTION
Currently it says that brms requires CmdStanR but it can use RStan (in fact RStan is the default backend). This PR updates the two places I found where it said that. 