### PR TITLE
Add a few missing URLS on the About page

### DIFF
--- a/mc-stan-org/about.qmd
+++ b/mc-stan-org/about.qmd
@@ -38,7 +38,7 @@ improved Stan's usability and reliability.
 for questions, discussion, and announcements related to Stan for
 both users and developers.  
 
-* Stan slack - developer discussions
+* [Stan slack](https://join.slack.com/t/mc-stan/shared_invite/zt-1le4ebi4m-UMtiOkJb4gcS16qz2wIYCw) - developer discussions
 
 * GitHub issues - report bugs
 

--- a/mc-stan-org/about.qmd
+++ b/mc-stan-org/about.qmd
@@ -40,7 +40,7 @@ both users and developers.
 
 * [Stan slack](https://join.slack.com/t/mc-stan/shared_invite/zt-1le4ebi4m-UMtiOkJb4gcS16qz2wIYCw) - developer discussions
 
-* GitHub issues - report bugs
+* [GitHub issues](https://github.com/stan-dev/) - report bugs
 
 
 ## Licensing


### PR DESCRIPTION
In the "Stan User and Developer Forums" sections of the About page, there are three items listed (forum, slack, and GitHub) but only the forum has a link. This PR adds the slack and stan-dev GitHub URLs. 

(There's also a "Contribute Expertise" section on the same page that looks like it needs URLs but I wasn't sure where they should go. Or maybe those bullet points weren't intended to link to anything.)