### PR TITLE
update "About Us" to list developers, acknowledge funders

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -50,7 +50,7 @@ website:
             href: learn-stan/publications.qmd
       - text: "Tools"
         href: tools/tools.qmd
-      - text: "About mc-stan.org"
+      - text: "About"
         href: mc-stan-org/about.qmd
     tools:
       - icon: github

--- a/index.qmd
+++ b/index.qmd
@@ -14,7 +14,7 @@ description: |
 ::: {.g-col-1}
 :::
 ::: {.g-col-8}
-# Stan: Software for Bayesian Data Analysis
+# Stan: Software&nbsp;for&nbsp;Bayesian&nbsp;Data&nbsp;Analysis
 :::
 :::
 :::

--- a/mc-stan-org/about.qmd
+++ b/mc-stan-org/about.qmd
@@ -12,8 +12,24 @@ is associated with NumFOCUS, a 501(c)(3) nonprofit supporting open code
 and reproducible science, through which you can [help support
 Stan](support.html#contribute-money).
 
+## Stan Development Team
 
-### Acknowledgements
+The project is a team effort comprised of full time and volunteer developers from around the world.
+
+* [Development Team Members and Collaborators](https://github.com/orgs/stan-dev/people)
+
+## Stan Community Forums
+
+* [Stan forums](https://discourse.mc-stan.org) -  message board
+for questions, discussion, and announcements related to Stan for
+both users and developers.  
+
+* [Stan slack](https://join.slack.com/t/mc-stan/shared_invite/zt-1le4ebi4m-UMtiOkJb4gcS16qz2wIYCw) - developer discussions
+
+* [GitHub issues](https://github.com/stan-dev/) - report bugs
+
+
+## Acknowledgements
 
 Stan has grown from a small research project started in 2011 at Columbia University
 to a global community of developers, researchers, and users.
@@ -37,24 +53,8 @@ the U.S. Office of Naval Research,
 the U.S. National Institutes of Health,
 the Alfred P. Sloan Foundation,
 and the Chan Zuckerberg Foundation,
-and by gifts from Google, and Facebook.
+and by gifts from Novartis, Google, and Facebook.
 Hosting and support for Stan's continuous integration testing is generously provided by the Simons Foundation.
-
-## Stan Development Team
-
-The project is a team effort comprised of full time and volunteer developers from around the world.
-
-* [Development Team Members and Collaborators](https://github.com/orgs/stan-dev/people)
-
-## Stan Community Forums
-
-* [Stan forums](https://discourse.mc-stan.org) -  message board
-for questions, discussion, and announcements related to Stan for
-both users and developers.  
-
-* [Stan slack](https://join.slack.com/t/mc-stan/shared_invite/zt-1le4ebi4m-UMtiOkJb4gcS16qz2wIYCw) - developer discussions
-
-* [GitHub issues](https://github.com/stan-dev/) - report bugs
 
 
 ## Licensing

--- a/mc-stan-org/about.qmd
+++ b/mc-stan-org/about.qmd
@@ -21,15 +21,29 @@ The Stan project owes its success to the contributions from hundreds of
 developers, researchers, active users, and funders.
 Individual contributions to the software and documentation can be tracked through GitHub.
 
+We are grateful to all the users who have taken the time to file bug reports and
+feature requests via the GitHub and the Stan forums; this feedback has greatly
+improved Stan's usability and reliability.
+
 Stan has been funded through grants for Stan and its developers,
 through in-kind donations in the form of companies contributing
 developer time to Stan and individuals contributing their own time to
 Stan, and through donations to the open-source scientific software
-non-profit NumFOCUS.
+non-profit NumFOCUS.   Stan development has been funded by grants from
+the U.S. Department of Energy,
+the U.S. Department of Education,
+the U.S. National Science Foundation,
+the U.S. Office of Naval Research,
+the U.S. National Institutes of Health,
+the Alfred P. Sloan Foundation,
+and the Chan Zuckerberg Foundation,
+and by gifts from Google, and Facebook.
 
-We are grateful to all the users who have taken the time to file bug reports and
-feature requests via the GitHub and the Stan forums; this feedback has greatly
-improved Stan's usability and reliability.
+## Stan Development Team
+
+The project is a team effort comprised of full time and volunteer developers from around the world.
+
+* [Development Team Members and Collaborators](https://github.com/orgs/stan-dev/people)
 
 ## Stan Community Forums
 
@@ -40,12 +54,6 @@ both users and developers.
 * [Stan slack](https://join.slack.com/t/mc-stan/shared_invite/zt-1le4ebi4m-UMtiOkJb4gcS16qz2wIYCw) - developer discussions
 
 * [GitHub issues](https://github.com/stan-dev/) - report bugs
-
-## Stan Development Team
-
-The project is a team effort comprised of full time and volunteer developers from around the world.
-
-* [Development Team Members and Collaborators](https://github.com/orgs/stan-dev/people)
 
 
 ## Licensing

--- a/mc-stan-org/about.qmd
+++ b/mc-stan-org/about.qmd
@@ -38,6 +38,7 @@ the U.S. National Institutes of Health,
 the Alfred P. Sloan Foundation,
 and the Chan Zuckerberg Foundation,
 and by gifts from Google, and Facebook.
+Hosting and support for Stan's continuous integration testing is generously provided by the Simons Foundation.
 
 ## Stan Development Team
 

--- a/mc-stan-org/about.qmd
+++ b/mc-stan-org/about.qmd
@@ -31,8 +31,7 @@ We are grateful to all the users who have taken the time to file bug reports and
 feature requests via the GitHub and the Stan forums; this feedback has greatly
 improved Stan's usability and reliability.
 
-
-## Stan User and Developer Forums
+## Stan Community Forums
 
 * [Stan forums](https://discourse.mc-stan.org) -  message board
 for questions, discussion, and announcements related to Stan for
@@ -41,6 +40,12 @@ both users and developers.
 * [Stan slack](https://join.slack.com/t/mc-stan/shared_invite/zt-1le4ebi4m-UMtiOkJb4gcS16qz2wIYCw) - developer discussions
 
 * [GitHub issues](https://github.com/stan-dev/) - report bugs
+
+## Stan Development Team
+
+The project is a team effort comprised of full time and volunteer developers from around the world.
+
+* [Development Team Members and Collaborators](https://github.com/orgs/stan-dev/people)
 
 
 ## Licensing


### PR DESCRIPTION
updated page `mc-stan-org/about.qmd`.
Developers point to github's `people` page.
Listed all funding agencies that have funded research at Columbia.
